### PR TITLE
chore: fixed LICENSE badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/thezak48/comps/actions/workflows/docker-build.yml/badge.svg)](https://github.com/thezak48/comps/actions/workflows/docker-build.yml)
 [![Docker Image Version](https://img.shields.io/docker/v/thezak48/comps?sort=semver)](https://hub.docker.com/r/thezak48/comps)
-[![License](https://img.shields.io/github/license/thezak48/comps)](https://github.com/thezak48/comps/blob/develop/LICENSE)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/thezak48/comps/blob/develop/LICENSE)
 [![Security Status](https://github.com/thezak48/comps/workflows/security/badge.svg)](https://github.com/thezak48/comps/security/advisories)
 
 Comps is a open source self hostable version of Slowpoke Pics. A web-based tool for comparing multiple images side by side.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/thezak48/comps/actions/workflows/docker-build.yml/badge.svg)](https://github.com/thezak48/comps/actions/workflows/docker-build.yml)
 [![Docker Image Version](https://img.shields.io/docker/v/thezak48/comps?sort=semver)](https://hub.docker.com/r/thezak48/comps)
-[![License](https://img.shields.io/github/license/thezak48/comps)](https://github.com/thezak48/comps/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/thezak48/comps)](https://github.com/thezak48/comps/blob/develop/LICENSE)
 [![Security Status](https://github.com/thezak48/comps/workflows/security/badge.svg)](https://github.com/thezak48/comps/security/advisories)
 
 Comps is a open source self hostable version of Slowpoke Pics. A web-based tool for comparing multiple images side by side.


### PR DESCRIPTION
it was pointed at `main` but the default branch is `develop`

<img width="427" height="80" alt="image" src="https://github.com/user-attachments/assets/ff8b31a1-2536-4a2d-a753-7039066467de" />
