### PR TITLE
fix(ui): constrain wide images to viewport width in fit-to-screen mode

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -333,6 +333,7 @@ body {
 }
 
 .comparison-image.fit {
+    max-width: 100%;
     max-height: calc(
         100vh - 76px
     ); /* Fallback for browsers that might not support dvh */


### PR DESCRIPTION
fix(ui): constrain wide images to viewport width in fit-to-screen mode
- Adds `max-width: 100%;` to `.comparison-image.fit`