### PR TITLE
fix(storage): s3 based images not using browser cache

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -12,11 +12,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: "3.14"
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          # eslint@10 requires Node ^20.19 || ^22.13 || >=24
+          node-version: "24"
       - name: Install Python dev dependencies
         run: |
           python -m venv .venv

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Comps supports both SQLite (default) and PostgreSQL.
 
 - SQLite (default): set DB_PATH to the SQLite file path (default: comparisons.db)
 - PostgreSQL: set DB_BACKEND=postgres and provide DATABASE_URL (or DB_URL) like:
-	- postgresql://user:pass@host:5432/dbname
+    - postgresql://user:pass@host:5432/dbname
 
 Migrations run automatically at startup for the selected backend.
 
@@ -47,13 +47,35 @@ Comps supports local filesystem storage (default) and S3-compatible object stora
 
 - Local (default): `STORAGE_BACKEND=local` and `UPLOADS_PATH` (default: `uploads`)
 - S3: set `STORAGE_BACKEND=s3` and:
-	- `S3_BUCKET_NAME=<bucket>`
-	- `S3_REGION=<region>` (optional, but recommended)
-	- `S3_ENDPOINT_URL=<endpoint>` (optional, for S3-compatible providers like MinIO)
-	- `S3_KEY_PREFIX=<prefix>` (optional)
-	- `S3_PRESIGNED_URL_TTL_SECONDS=<seconds>` (optional, default: `3600`)
+    - `S3_BUCKET_NAME=<bucket>`
+    - `S3_REGION=<region>` (optional, but recommended)
+    - `S3_ENDPOINT_URL=<endpoint>` (optional, for S3-compatible providers like MinIO)
+    - `S3_KEY_PREFIX=<prefix>` (optional)
+    - `S3_PUBLIC_BASE_URL=<public-domain>` (optional, use when the bucket is publicly served through a custom domain/CDN)
+    - `S3_PRESIGNED_URL_TTL_SECONDS=<seconds>` (optional, default: `3600`)
 
-When S3 is enabled, `/uploads/<comparison_id>/<filename>` redirects to a short-lived pre-signed S3 URL.
+    When `S3_PUBLIC_BASE_URL` is set, Comps embeds direct public image URLs in the comparison page and skips presigned redirects for browser image loads. Otherwise, `/uploads/<comparison_id>/<filename>` redirects to a short-lived pre-signed S3 URL.
+
+    Example: Cloudflare R2 with a public custom domain
+
+    ```bash
+    STORAGE_BACKEND=s3
+    S3_BUCKET_NAME=comps-images
+    S3_REGION=auto
+    S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+    S3_PUBLIC_BASE_URL=https://images.example.com
+    S3_KEY_PREFIX=comps
+    ```
+
+    Use your normal S3-compatible credentials for uploads and deletes. The browser-facing image URLs will come from `S3_PUBLIC_BASE_URL`, while the app still talks to the R2 S3 API endpoint for storage operations.
+
+    If you use canvas-based features like solarization, make sure the public domain sends a CORS header similar to:
+
+    ```http
+    Access-Control-Allow-Origin: https://comp.example.com
+    ```
+
+    If the public asset domain is used from multiple sites, allow only the specific origins you trust rather than using `*`.
 
 ### Migrating existing local uploads to S3
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -22,18 +22,18 @@ docker-compose up -d
 
 1. Clone the repository
 2. Create a virtual environment:
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
 3. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
+    ```bash
+    pip install -r requirements.txt
+    ```
 4. Run the application:
-   ```bash
-   uvicorn main:app --host 0.0.0.0 --port 8000
-   ```
+    ```bash
+    uvicorn main:app --host 0.0.0.0 --port 8000
+    ```
 5. Access the application at http://localhost:8000
 
 ## Database configuration
@@ -44,8 +44,8 @@ To use PostgreSQL instead:
 
 - Install dependencies: psycopg (included in requirements.txt)
 - Set environment variables:
-  - `DB_BACKEND=postgres`
-  - `DATABASE_URL=postgresql://user:pass@host:5432/dbname`
+    - `DB_BACKEND=postgres`
+    - `DATABASE_URL=postgresql://user:pass@host:5432/dbname`
 
 Migrations are applied automatically at startup.
 
@@ -60,7 +60,31 @@ To use S3-compatible storage:
 - `S3_REGION=<region>` (optional, recommended)
 - `S3_ENDPOINT_URL=<endpoint-url>` (optional, for MinIO/other compatible services)
 - `S3_KEY_PREFIX=<prefix>` (optional)
+- `S3_PUBLIC_BASE_URL=<public-domain>` (optional, use when the bucket is publicly served through a custom domain/CDN)
 - `S3_PRESIGNED_URL_TTL_SECONDS=<seconds>` (optional, default `3600`)
+
+If `S3_PUBLIC_BASE_URL` is set, Comps will generate direct browser image URLs against that public domain instead of using presigned redirects.
+
+Example: Cloudflare R2 with a public custom domain
+
+```bash
+STORAGE_BACKEND=s3
+S3_BUCKET_NAME=comps-images
+S3_REGION=auto
+S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+S3_PUBLIC_BASE_URL=https://images.example.com
+S3_KEY_PREFIX=comps
+```
+
+Use your normal S3-compatible credentials for uploads and deletes. The browser-facing image URLs will come from `S3_PUBLIC_BASE_URL`, while the app still talks to the R2 S3 API endpoint for storage operations.
+
+If you use canvas-based features like solarization, make sure the public domain sends a CORS header similar to:
+
+```http
+Access-Control-Allow-Origin: https://comp.example.com
+```
+
+If the public asset domain is used from multiple sites, allow only the specific origins you trust rather than using `*`.
 
 To migrate existing local uploads into S3 after switching storage backend:
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from fastapi.security import APIKeyCookie
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
 
 import auth
 from api.router import router as api_router
@@ -153,7 +154,11 @@ async def serve_uploaded_image(path: str):
         raise HTTPException(status_code=404, detail="Image not found")
 
     try:
-        presigned_url = get_presigned_image_url(comparison_id, filename)
+        presigned_url = await run_in_threadpool(
+            get_presigned_image_url,
+            comparison_id,
+            filename,
+        )
         return RedirectResponse(url=presigned_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e

--- a/main.py
+++ b/main.py
@@ -32,7 +32,12 @@ from database import (
 )
 from database_metrics import get_metrics
 from db import backend_name, query_dicts
-from storage import ensure_storage_ready, get_presigned_image_url, is_s3_enabled
+from storage import (
+    ensure_storage_ready,
+    get_browser_image_url,
+    get_presigned_image_url,
+    is_s3_enabled,
+)
 
 
 # Random name generator for comparisons
@@ -154,6 +159,13 @@ async def serve_uploaded_image(path: str):
         raise HTTPException(status_code=404, detail="Image not found")
 
     try:
+        if is_s3_enabled():
+            public_url = get_browser_image_url(comparison_id, filename)
+            if public_url != f"/uploads/{comparison_id}/{filename}":
+                return RedirectResponse(
+                    url=public_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT
+                )
+
         presigned_url = await run_in_threadpool(
             get_presigned_image_url,
             comparison_id,
@@ -486,7 +498,7 @@ async def view_comparison(request: Request, comparison_id: str):
     image_sizes = []
 
     for row in rows:
-        images.append(f"{comparison_id}/{row['filename']}")
+        images.append(get_browser_image_url(comparison_id, row["filename"]))
         # Use custom name if available, otherwise use original filename
         image_names.append(row.get("custom_name") or row.get("original_filename"))
         image_sizes.append(row.get("image_size"))

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "comps-static",
       "version": "1.0.0",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.6.2",
@@ -370,6 +371,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "npm run lint:js && npm run lint:css && npm run prettier:check"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.6.2",

--- a/scripts/migrate_local_uploads_to_s3.py
+++ b/scripts/migrate_local_uploads_to_s3.py
@@ -16,11 +16,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import mimetypes
 import os
 import sys
+import threading
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
@@ -30,7 +32,7 @@ ROOT = str(Path(__file__).resolve().parents[1])
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from db import execute, query, query_one  # noqa: E402
+from db import executemany, query  # noqa: E402
 
 
 def _object_key(prefix: str, comparison_id: str, filename: str) -> str:
@@ -55,35 +57,101 @@ def _file_records() -> List[Tuple[str, str, str]]:
     return [(str(r[0]), str(r[1]), str(r[2])) for r in rows]
 
 
-def _upsert_image_metadata(
-    comparison_id: str,
-    filename: str,
-    original_filename: str,
-    image_size: str,
-):
-    existing = query_one(
-        "SELECT id FROM image_metadata WHERE comparison_id = ? AND filename = ?",
-        (comparison_id, filename),
-    )
-    if existing:
-        execute(
+def _load_existing_metadata_keys() -> Set[Tuple[str, str]]:
+    rows = query("SELECT comparison_id, filename FROM image_metadata")
+    return {(str(r[0]), str(r[1])) for r in rows}
+
+
+def _flush_metadata_updates(
+    pending_updates: List[Tuple[str, str, str, str]],
+    existing_keys: Set[Tuple[str, str]],
+) -> int:
+    if not pending_updates:
+        return 0
+
+    to_update: List[Tuple[str, str, str, str]] = []
+    to_insert: List[Tuple[str, str, str, str]] = []
+
+    for comparison_id, filename, original_filename, image_size in pending_updates:
+        key = (comparison_id, filename)
+        if key in existing_keys:
+            to_update.append((image_size, original_filename, comparison_id, filename))
+        else:
+            to_insert.append((comparison_id, filename, original_filename, image_size))
+            existing_keys.add(key)
+
+    if to_update:
+        executemany(
             """
             UPDATE image_metadata
             SET image_size = ?,
                 original_filename = COALESCE(original_filename, ?)
             WHERE comparison_id = ? AND filename = ?
             """,
-            (image_size, original_filename, comparison_id, filename),
+            to_update,
         )
-    else:
-        execute(
+
+    if to_insert:
+        executemany(
             """
             INSERT INTO image_metadata (
                 comparison_id, filename, original_filename, image_size
             ) VALUES (?, ?, ?, ?)
             """,
-            (comparison_id, filename, original_filename, image_size),
+            to_insert,
         )
+
+    pending_updates.clear()
+    return len(to_update) + len(to_insert)
+
+
+def _process_record(
+    client,
+    bucket: str,
+    normalized_prefix: str,
+    expected_bucket_owner: str,
+    skip_existing: bool,
+    dry_run: bool,
+    local_file: Path,
+    comparison_id: str,
+    filename: str,
+    original_filename: str,
+) -> Tuple[str, Optional[Tuple[str, str, str, str]]]:
+    key = _object_key(normalized_prefix, comparison_id, filename)
+    if not local_file.is_file():
+        return "missing_local", None
+
+    file_size = local_file.stat().st_size
+    image_size = f"{file_size} bytes"
+    content_type = mimetypes.guess_type(str(local_file))[0] or "application/octet-stream"
+    metadata_update = (comparison_id, filename, original_filename, image_size)
+
+    if skip_existing:
+        head_kwargs = {
+            "Bucket": bucket,
+            "Key": key,
+        }
+        if expected_bucket_owner:
+            head_kwargs["ExpectedBucketOwner"] = expected_bucket_owner
+
+        try:
+            client.head_object(**head_kwargs)
+            return "already_present", metadata_update if not dry_run else None
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code not in {"404", "NoSuchKey", "NotFound"}:
+                raise
+
+    if not dry_run:
+        client.upload_file(
+            str(local_file),
+            bucket,
+            key,
+            ExtraArgs={
+                "ContentType": content_type,
+            },
+        )
+    return "uploaded", metadata_update if not dry_run else None
 
 
 def migrate(
@@ -96,6 +164,8 @@ def migrate(
     skip_existing: bool,
     dry_run: bool,
     progress_interval: int,
+    workers: int,
+    db_batch_size: int,
 ) -> Dict[str, int]:
     if not bucket:
         raise RuntimeError("S3 bucket is required (set --bucket or S3_BUCKET_NAME)")
@@ -123,6 +193,13 @@ def migrate(
     print(f"Found {stats['total']} image records to process.", flush=True)
 
     safe_interval = max(1, progress_interval)
+    safe_workers = max(1, workers)
+    safe_db_batch_size = max(1, db_batch_size)
+
+    pending_updates: List[Tuple[str, str, str, str]] = []
+    existing_keys: Set[Tuple[str, str]] = set()
+    if not dry_run:
+        existing_keys = _load_existing_metadata_keys()
 
     def report_progress(force: bool = False):
         if (
@@ -143,71 +220,63 @@ def migrate(
             flush=True,
         )
 
-    for comparison_id, filename, original_filename in records:
-        local_file = base_path / comparison_id / filename
-        key = _object_key(normalized_prefix, comparison_id, filename)
+    flush_lock = threading.Lock()
 
-        if not local_file.is_file():
-            stats["missing_local"] += 1
-            stats["processed"] += 1
-            report_progress()
-            continue
+    def maybe_flush_metadata(force: bool = False):
+        if dry_run:
+            return
+        with flush_lock:
+            if not pending_updates:
+                return
+            if not force and len(pending_updates) < safe_db_batch_size:
+                return
+            stats["db_updates"] += _flush_metadata_updates(pending_updates, existing_keys)
 
-        file_size = local_file.stat().st_size
-        image_size = f"{file_size} bytes"
-        content_type = mimetypes.guess_type(str(local_file))[0] or "application/octet-stream"
+    with concurrent.futures.ThreadPoolExecutor(max_workers=safe_workers) as executor:
+        future_map = {
+            executor.submit(
+                _process_record,
+                client,
+                bucket,
+                normalized_prefix,
+                expected_bucket_owner,
+                skip_existing,
+                dry_run,
+                base_path / comparison_id / filename,
+                comparison_id,
+                filename,
+                original_filename,
+            ): (comparison_id, filename)
+            for comparison_id, filename, original_filename in records
+        }
 
-        if skip_existing:
-            try:
-                if not dry_run:
-                    head_kwargs = {
-                        "Bucket": bucket,
-                        "Key": key,
-                    }
-                    if expected_bucket_owner:
-                        head_kwargs["ExpectedBucketOwner"] = expected_bucket_owner
-
-                    client.head_object(
-                        **head_kwargs,
-                    )
-                stats["already_present"] += 1
-                if not dry_run:
-                    _upsert_image_metadata(comparison_id, filename, original_filename, image_size)
-                    stats["db_updates"] += 1
-                stats["processed"] += 1
-                report_progress()
-                continue
-            except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code")
-                if code not in {"404", "NoSuchKey", "NotFound"}:
+        try:
+            for future in concurrent.futures.as_completed(future_map):
+                try:
+                    outcome, metadata_update = future.result()
+                except (ClientError, BotoCoreError, OSError):
                     stats["processed"] += 1
                     stats["errors"] += 1
                     report_progress(force=True)
+                    for pending_future in future_map:
+                        pending_future.cancel()
                     raise
 
-        try:
-            extra_args = {
-                "ContentType": content_type,
-            }
-            if expected_bucket_owner:
-                extra_args["ExpectedBucketOwner"] = expected_bucket_owner
-            if not dry_run:
-                client.upload_file(
-                    str(local_file),
-                    bucket,
-                    key,
-                    ExtraArgs=extra_args,
-                )
-                _upsert_image_metadata(comparison_id, filename, original_filename, image_size)
-                stats["db_updates"] += 1
-            stats["uploaded"] += 1
-        except (ClientError, BotoCoreError, OSError):
-            stats["errors"] += 1
-            stats["processed"] += 1
-            report_progress(force=True)
-            raise
-        stats["processed"] += 1
-        report_progress()
+                if outcome == "uploaded":
+                    stats["uploaded"] += 1
+                elif outcome == "already_present":
+                    stats["already_present"] += 1
+                elif outcome == "missing_local":
+                    stats["missing_local"] += 1
+
+                if metadata_update is not None:
+                    pending_updates.append(metadata_update)
+                    maybe_flush_metadata()
+
+                stats["processed"] += 1
+                report_progress()
+        finally:
+            maybe_flush_metadata(force=True)
 
     report_progress(force=True)
 
@@ -264,6 +333,18 @@ def main():
         default=25,
         help="Print progress every N processed records (default: 25)",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=int(os.getenv("MIGRATION_WORKERS", "16")),
+        help="Number of concurrent worker threads for S3 operations (default: 16)",
+    )
+    parser.add_argument(
+        "--db-batch-size",
+        type=int,
+        default=int(os.getenv("MIGRATION_DB_BATCH_SIZE", "500")),
+        help="Number of metadata rows to batch per DB write (default: 500)",
+    )
     args = parser.parse_args()
 
     stats = migrate(
@@ -276,6 +357,8 @@ def main():
         skip_existing=args.skip_existing,
         dry_run=args.dry_run,
         progress_interval=args.progress_interval,
+        workers=args.workers,
+        db_batch_size=args.db_batch_size,
     )
 
     print("Migration completed.")

--- a/static/js/compare.js
+++ b/static/js/compare.js
@@ -45,6 +45,18 @@ function solarCurve(x, t = 5, k = 5.5) {
 const STORAGE_KEY = "solarizationCurves";
 let solarizationInProgress = false;
 
+function resolveImageUrl(url) {
+    if (
+        url.startsWith("http://") ||
+        url.startsWith("https://") ||
+        url.startsWith("/")
+    ) {
+        return url;
+    }
+
+    return `/uploads/${url}`;
+}
+
 // Modify generateSolarCurves to use localStorage
 function generateSolarCurves() {
     // Try to load from localStorage first
@@ -90,7 +102,7 @@ function preloadImages() {
             img.crossOrigin = "anonymous";
             img.onload = () => resolve(url);
             img.onerror = () => reject(url);
-            img.src = `/uploads/${url}`;
+            img.src = resolveImageUrl(url);
         });
     });
 
@@ -352,7 +364,7 @@ function updateDisplay() {
                     currentImage.src = solarizedDataUrl;
                 } catch (e) {
                     isSolarized = false;
-                    currentImage.src = `/uploads/${currentUrl}`;
+                    currentImage.src = resolveImageUrl(currentUrl);
                     if (!solarizationUnsupportedNotified) {
                         solarizationUnsupportedNotified = true;
                         console.warn(
@@ -371,10 +383,10 @@ function updateDisplay() {
                 solarizationInProgress = false;
                 console.error("Failed to load image for solarization");
             };
-            img.src = `/uploads/${currentUrl}`;
+            img.src = resolveImageUrl(currentUrl);
         }
     } else {
-        currentImage.src = `/uploads/${imageUrls[absoluteIndex]}`;
+        currentImage.src = resolveImageUrl(imageUrls[absoluteIndex]);
     }
 
     applyZoom();
@@ -716,7 +728,7 @@ function generateBBCode() {
             const index = row * totalColumns + col;
 
             if (index < imageUrls.length) {
-                bbcode += `${window.location.origin}/uploads/${imageUrls[index]}\n`;
+                bbcode += `${resolveImageUrl(imageUrls[index])}\n`;
             }
         }
     }

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -20,7 +20,7 @@ function showToast(message, type = "error", duration = 5000) {
     toast.className = `toast ${type}`;
 
     // Add icon based on type
-    let icon = "";
+    let icon;
     switch (type) {
         case "error":
             icon = "❌";
@@ -1275,14 +1275,12 @@ function openRenameColumnModal(columnIndex) {
             }
         }
 
-        let previewText = "";
-        if (numberingOption === "append") {
-            previewText = `${baseName}-1, ${baseName}-2, ${baseName}-3, ...`;
-        } else if (numberingOption === "prepend") {
-            previewText = `1-${baseName}, 2-${baseName}, 3-${baseName}, ...`;
-        } else {
-            previewText = `${baseName}, ${baseName}, ${baseName}, ...`;
-        }
+        const previewText =
+            numberingOption === "append"
+                ? `${baseName}-1, ${baseName}-2, ${baseName}-3, ...`
+                : numberingOption === "prepend"
+                  ? `1-${baseName}, 2-${baseName}, 3-${baseName}, ...`
+                  : `${baseName}, ${baseName}, ${baseName}, ...`;
 
         namePreview.innerHTML = `<code>${previewText}</code>`;
     }

--- a/storage.py
+++ b/storage.py
@@ -1,6 +1,8 @@
 import mimetypes
 import os
 import shutil
+import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -18,8 +20,12 @@ S3_REGION = os.getenv("S3_REGION")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
 S3_KEY_PREFIX = os.getenv("S3_KEY_PREFIX", "").strip().strip("/")
 S3_PRESIGNED_URL_TTL_SECONDS = int(os.getenv("S3_PRESIGNED_URL_TTL_SECONDS", "3600"))
+S3_PRESIGNED_URL_CACHE_MAX_SIZE = int(os.getenv("S3_PRESIGNED_URL_CACHE_MAX_SIZE", "10000"))
 
 _s3_client = None
+_presigned_url_cache: dict[str, tuple[str, float]] = {}
+_presigned_url_cache_lock = threading.Lock()
+_PRESIGNED_URL_REFRESH_SKEW_SECONDS = 5
 
 
 def is_s3_enabled() -> bool:
@@ -59,6 +65,7 @@ async def save_upload_file(comparison_id: str, filename: str, file: UploadFile) 
 
     if is_s3_enabled():
         key = _get_object_key(safe_comparison_id, safe_filename)
+        _evict_presigned_url_cache(keys=[key])
         try:
             client = _get_s3_client()
             await run_in_threadpool(
@@ -91,15 +98,21 @@ def get_presigned_image_url(comparison_id: str, filename: str) -> str:
     safe_comparison_id = _normalize_comparison_id(comparison_id)
     safe_filename = _normalize_filename(filename)
     key = _get_object_key(safe_comparison_id, safe_filename)
+    cached_url = _get_cached_presigned_url(key)
+    if cached_url:
+        return cached_url
+
     try:
         client = _get_s3_client()
         client.head_object(Bucket=S3_BUCKET_NAME, Key=key)
         expires_in = max(1, S3_PRESIGNED_URL_TTL_SECONDS)
-        return client.generate_presigned_url(
+        presigned_url = client.generate_presigned_url(
             "get_object",
             Params={"Bucket": S3_BUCKET_NAME, "Key": key},
             ExpiresIn=expires_in,
         )
+        _cache_presigned_url(key, presigned_url, expires_in)
+        return presigned_url
     except ClientError as exc:
         error_code = exc.response.get("Error", {}).get("Code")
         if error_code in {"NoSuchKey", "404", "NotFound"}:
@@ -126,10 +139,12 @@ def delete_comparison_assets(
                 _get_object_key(safe_comparison_id, _normalize_filename(filename))
                 for filename in filenames
             ]
+            _evict_presigned_url_cache(keys=keys)
             _delete_s3_keys(client, keys)
             return
 
         prefix = _get_object_key_prefix(safe_comparison_id)
+        _evict_presigned_url_cache(prefix=prefix)
         keys = []
         continuation_token = None
         try:
@@ -201,6 +216,56 @@ def _delete_s3_keys(client, keys: list[str]):
                 for err in errors
             )
             raise OSError(f"S3 reported delete errors: {details}")
+
+
+def _get_cached_presigned_url(key: str) -> Optional[str]:
+    now = time.monotonic()
+    with _presigned_url_cache_lock:
+        cached = _presigned_url_cache.get(key)
+        if not cached:
+            return None
+
+        cached_url, expires_at = cached
+        if expires_at - _PRESIGNED_URL_REFRESH_SKEW_SECONDS <= now:
+            _presigned_url_cache.pop(key, None)
+            return None
+
+        return cached_url
+
+
+def _cache_presigned_url(key: str, url: str, expires_in: int):
+    now = time.monotonic()
+    expires_at = now + max(1, expires_in)
+    with _presigned_url_cache_lock:
+        _prune_presigned_url_cache(now)
+        _presigned_url_cache[key] = (url, expires_at)
+
+        # Keep cache bounded to avoid unbounded memory growth.
+        max_size = max(1, S3_PRESIGNED_URL_CACHE_MAX_SIZE)
+        while len(_presigned_url_cache) > max_size:
+            oldest_key = next(iter(_presigned_url_cache))
+            _presigned_url_cache.pop(oldest_key, None)
+
+
+def _evict_presigned_url_cache(
+    keys: Optional[list[str]] = None,
+    prefix: Optional[str] = None,
+):
+    with _presigned_url_cache_lock:
+        if keys:
+            for key in keys:
+                _presigned_url_cache.pop(key, None)
+
+        if prefix:
+            for key in list(_presigned_url_cache):
+                if key.startswith(prefix):
+                    _presigned_url_cache.pop(key, None)
+
+
+def _prune_presigned_url_cache(now: float):
+    for cache_key, (_, expires_at) in list(_presigned_url_cache.items()):
+        if expires_at - _PRESIGNED_URL_REFRESH_SKEW_SECONDS <= now:
+            _presigned_url_cache.pop(cache_key, None)
 
 
 def _normalize_comparison_id(comparison_id: str) -> str:

--- a/storage.py
+++ b/storage.py
@@ -19,6 +19,7 @@ S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "").strip()
 S3_REGION = os.getenv("S3_REGION")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
 S3_KEY_PREFIX = os.getenv("S3_KEY_PREFIX", "").strip().strip("/")
+S3_PUBLIC_BASE_URL = os.getenv("S3_PUBLIC_BASE_URL", "").strip().rstrip("/")
 S3_PRESIGNED_URL_TTL_SECONDS = int(os.getenv("S3_PRESIGNED_URL_TTL_SECONDS", "3600"))
 S3_PRESIGNED_URL_CACHE_MAX_SIZE = int(os.getenv("S3_PRESIGNED_URL_CACHE_MAX_SIZE", "10000"))
 
@@ -122,6 +123,20 @@ def get_presigned_image_url(comparison_id: str, filename: str) -> str:
         raise OSError(f"Failed to generate S3 URL for {safe_filename}: {exc}") from exc
     except BotoCoreError as exc:
         raise OSError(f"Failed to generate S3 URL for {safe_filename}: {exc}") from exc
+
+
+def get_browser_image_url(comparison_id: str, filename: str) -> str:
+    safe_comparison_id = _normalize_comparison_id(comparison_id)
+    safe_filename = _normalize_filename(filename)
+    key = _get_object_key(safe_comparison_id, safe_filename)
+
+    if S3_PUBLIC_BASE_URL:
+        return f"{S3_PUBLIC_BASE_URL}/{key}"
+
+    if is_s3_enabled():
+        return f"/uploads/{safe_comparison_id}/{safe_filename}"
+
+    return f"/uploads/{safe_comparison_id}/{safe_filename}"
 
 
 def delete_comparison_assets(

--- a/templates/compare.jinja
+++ b/templates/compare.jinja
@@ -200,7 +200,7 @@
         <div class="image-container">
             <img
                     id="currentImage"
-                    src="{{ url_for('uploads', path=images[0]) }}"
+                    src="{{ images[0] }}"
                     alt="Comparison image"
                     class="comparison-image fit"
             />


### PR DESCRIPTION
This pull request adds an in-memory caching layer for S3 presigned URLs in `storage.py` to improve performance and reduce unnecessary S3 calls. The cache is thread-safe, supports eviction on asset changes, and ensures URLs are refreshed before expiration. The main changes are grouped below:

**Presigned URL Caching:**

* Introduced a thread-safe in-memory cache (`_presigned_url_cache`) for S3 presigned URLs, including logic to store, retrieve, and evict cached URLs with expiration handling. [[1]](diffhunk://#diff-a1945832a9b4ca40a852c04e82b29706d275f6b2d745b42fa448b13430edededR4-R5) [[2]](diffhunk://#diff-a1945832a9b4ca40a852c04e82b29706d275f6b2d745b42fa448b13430edededR25-R27) [[3]](diffhunk://#diff-a1945832a9b4ca40a852c04e82b29706d275f6b2d745b42fa448b13430edededR220-R255)
* Updated `get_presigned_image_url` to use the cache, returning a cached URL if available and valid, and caching new URLs after generation.

**Cache Invalidation:**

* Added cache eviction logic in `save_upload_file` and `delete_comparison_assets` to ensure the cache remains consistent when assets are added or deleted. [[1]](diffhunk://#diff-a1945832a9b4ca40a852c04e82b29706d275f6b2d745b42fa448b13430edededR67) [[2]](diffhunk://#diff-a1945832a9b4ca40a852c04e82b29706d275f6b2d745b42fa448b13430edededR141-R146)