### PR TITLE
fix: security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             - name: Install Python lint dependencies
               run: python -m pip install -r requirements-dev.txt
             - name: Install Node.js dependencies
-              run: npm ci
+              run: npm ci --ignore-scripts
             - name: Run Black
               run: black --check .
             - name: Run isort
@@ -91,9 +91,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
             - name: Build image for validation
-              uses: docker/build-push-action@v7
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                   context: .
                   load: true
@@ -119,7 +119,7 @@ jobs:
             - name: Docker metadata
               if: github.event_name == 'push'
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
               with:
                   images: |
                       ghcr.io/thezak48/comps
@@ -135,21 +135,21 @@ jobs:
                       type=sha
             - name: Login to GHCR
               if: github.event_name == 'push'
-              uses: docker/login-action@v4
+              uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ github.token }}
             - name: Login to Docker Hub
               if: github.event_name == 'push'
-              uses: docker/login-action@v4
+              uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
               with:
                   registry: docker.io
                   username: ${{ vars.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: Publish multi-platform image
               if: github.event_name == 'push'
-              uses: docker/build-push-action@v7
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                   context: .
                   platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ ENV PGID=1000
 ENV DB_PATH=/config/comparisons.db
 ENV UPLOADS_PATH=/data/uploads
 ENV RETENTION_DAYS=7
-ENV ADMIN_INVITATION_CODE=change-me-in-production
 
 # Expose port
 EXPOSE 8000

--- a/api/models.py
+++ b/api/models.py
@@ -117,6 +117,17 @@ class ComparisonResponse(ComparisonBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class ComparisonCreateResponse(ComparisonResponse):
+    edit_token: Optional[str] = Field(
+        None,
+        description=(
+            "Secret token authorizing later writes to this comparison. Returned only "
+            "when the comparison has no owner. Send it as the X-Edit-Token header."
+        ),
+        examples=["3sJ1w0Yk9m2QpX7bN4vRtLzC6hA8dEfG"],
+    )
+
+
 class ImageDetail(BaseModel):
     filename: str = Field(
         ...,

--- a/api/router.py
+++ b/api/router.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyCookie, OAuth2PasswordRequestForm
+from PIL import Image
 
 import auth
 from database import (
@@ -26,7 +27,7 @@ from database import (
     update_last_accessed,
 )
 from db import query, query_dicts
-from storage import create_comparison_storage, save_upload_file
+from storage import ALLOWED_IMAGE_EXTENSIONS, create_comparison_storage, save_upload_file
 
 from .models import (
     ComparisonCreate,
@@ -497,7 +498,19 @@ async def api_upload_image(
     _authorize_comparison_write(request, comparison_id, comparison, user)
 
     safe_name = file.filename or ""
-    file_ext = Path(safe_name).suffix
+    file_ext = Path(safe_name).suffix.lower()
+    if file_ext not in ALLOWED_IMAGE_EXTENSIONS:
+        return JSONResponse(status_code=400, content={"error": "Unsupported image type"})
+
+    # An allowed extension is not evidence of an image, so confirm the bytes decode.
+    await file.seek(0)
+    try:
+        with Image.open(file.file) as probe:
+            probe.verify()
+    except Exception:
+        return JSONResponse(status_code=400, content={"error": "File is not a valid image"})
+    await file.seek(0)
+
     unique_filename = f"{uuid.uuid4()}{file_ext}"
     try:
         image_size = await save_upload_file(comparison_id, unique_filename, file)

--- a/api/router.py
+++ b/api/router.py
@@ -1,5 +1,9 @@
+import hashlib
 import logging
+import os
 import random
+import secrets
+import time
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -14,6 +18,8 @@ from database import (
     create_comparison,
     delete_comparison,
     get_comparison,
+    get_comparison_edit_token,
+    set_comparison_edit_token,
     store_image_metadata,
     store_image_position,
     update_image_custom_name,
@@ -24,6 +30,7 @@ from storage import create_comparison_storage, save_upload_file
 
 from .models import (
     ComparisonCreate,
+    ComparisonCreateResponse,
     ComparisonDetail,
     ComparisonResponse,
     CustomNameUpdate,
@@ -34,6 +41,13 @@ from .models import (
 router = APIRouter(prefix="/api/v1", tags=["api"])
 
 MAX_ROWS = 200
+
+EDIT_TOKEN_HEADER = "X-Edit-Token"
+
+# How long an ownerless comparison stays writable after creation. The browser holds
+# the token only for the duration of the upload, so this bounds the capability
+# server-side rather than relying on the client having discarded it.
+EDIT_TOKEN_TTL_SECONDS = int(os.getenv("EDIT_TOKEN_TTL_SECONDS", str(24 * 60 * 60)))
 
 logger = logging.getLogger(__name__)
 cookie_sec = APIKeyCookie(name="session")
@@ -105,6 +119,43 @@ def generate_random_name():
     return f"{adjective} {noun}"
 
 
+def _hash_edit_token(token: str) -> str:
+    """Hash an edit token for storage. Tokens are high-entropy, so a plain digest suffices."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _issue_edit_token(comparison_id: str) -> str:
+    """Generate an edit token for a comparison and persist only its hash and expiry."""
+    token = secrets.token_urlsafe(32)
+    expires_at = int(time.time()) + EDIT_TOKEN_TTL_SECONDS
+    set_comparison_edit_token(comparison_id, _hash_edit_token(token), expires_at)
+    return token
+
+
+def _authorize_comparison_write(
+    request: Request, comparison_id: str, comparison: dict, user: Optional[dict]
+):
+    """Authorize a write to a comparison.
+
+    An owned comparison is gated by ownership. An ownerless one has no owner to
+    check, so it is gated by the edit token issued at creation, which the creator
+    holds only for the duration of the upload.
+    """
+    auth.require_comparison_write_access(comparison, user)
+    if comparison.get("user_id") is not None:
+        return
+
+    supplied = request.headers.get(EDIT_TOKEN_HEADER)
+    stored, expires_at = get_comparison_edit_token(comparison_id)
+    if supplied and stored and secrets.compare_digest(_hash_edit_token(supplied), stored):
+        # A token issued before this column existed has no expiry recorded; treat it
+        # as expired rather than granting an unbounded capability.
+        if expires_at is not None and int(time.time()) <= expires_at:
+            return
+
+    raise HTTPException(status_code=403, detail="Not authorized to modify this comparison")
+
+
 @router.post("/login")
 async def api_login(form_data: OAuth2PasswordRequestForm = Depends()):
     """
@@ -171,7 +222,7 @@ async def list_comparisons(request: Request):
     return comparisons
 
 
-@router.post("/comparisons", response_model=ComparisonResponse, status_code=201)
+@router.post("/comparisons", response_model=ComparisonCreateResponse, status_code=201)
 async def create_new_comparison(
     comparison_data: ComparisonCreate,
     user: Optional[dict] = Depends(auth.get_optional_user),
@@ -214,8 +265,11 @@ async def create_new_comparison(
         user_id=user_id,
     )
 
+    # An ownerless comparison has no owner to authorize later writes, so issue a token.
+    edit_token = _issue_edit_token(comparison_id) if user_id is None else None
+
     # Return the response
-    return ComparisonResponse(
+    return ComparisonCreateResponse(
         id=comparison_id,
         name=name,
         show_name=comparison_data.show_name,
@@ -226,6 +280,7 @@ async def create_new_comparison(
         expiration_days=int(metadata.get("expiration_days", 7)),
         created_at=datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
         last_accessed=datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        edit_token=edit_token,
     )
 
 
@@ -287,6 +342,7 @@ async def get_comparison_detail(comparison_id: str):
 
 @router.put("/comparisons/{comparison_id}/images/{filename}", status_code=200)
 async def update_image_metadata(
+    request: Request,
     comparison_id: str,
     filename: str,
     update_data: CustomNameUpdate,
@@ -305,7 +361,7 @@ async def update_image_metadata(
     comparison_data = get_comparison(comparison_id)
     if not comparison_data:
         raise HTTPException(status_code=404, detail="Comparison not found")
-    auth.require_comparison_write_access(comparison_data, user)
+    _authorize_comparison_write(request, comparison_id, comparison_data, user)
 
     # Check if file exists
     rows = query(
@@ -405,11 +461,17 @@ async def api_create_comparison(
         user_id=user_id,
     )
 
-    return JSONResponse(content={"comparison_id": comparison_id})
+    response_body = {"comparison_id": comparison_id}
+    # An ownerless comparison has no owner to authorize later writes, so issue a token.
+    if user_id is None:
+        response_body["edit_token"] = _issue_edit_token(comparison_id)
+
+    return JSONResponse(content=response_body)
 
 
 @router.post("/comparison/{comparison_id}/image")
 async def api_upload_image(
+    request: Request,
     comparison_id: str,
     file: UploadFile = File(...),
     row: int = Form(...),
@@ -432,7 +494,7 @@ async def api_upload_image(
     comparison = get_comparison(comparison_id)
     if not comparison:
         return JSONResponse(status_code=404, content={"error": "Comparison not found"})
-    auth.require_comparison_write_access(comparison, user)
+    _authorize_comparison_write(request, comparison_id, comparison, user)
 
     safe_name = file.filename or ""
     file_ext = Path(safe_name).suffix

--- a/api/router.py
+++ b/api/router.py
@@ -124,24 +124,32 @@ async def api_login(form_data: OAuth2PasswordRequestForm = Depends()):
 
 
 @router.get("/comparisons", response_model=List[ComparisonResponse])
-async def list_comparisons():
+async def list_comparisons(request: Request):
     """
-    List all available comparisons.
+    List comparisons visible to the authenticated caller.
 
-    Returns a list of all comparisons with their basic metadata including:
+    Regular users receive their own comparisons. Admins receive all of them.
+
+    Returns a list of comparisons with their basic metadata including:
     - ID, name, and show name
     - Tags
     - Grid dimensions (rows and columns)
     - Expiration settings
     - Creation and last accessed timestamps
     """
-    rows = query_dicts(
-        (
-            "SELECT id, name, show_name, total_rows, total_columns, "
-            "expiration_type, expiration_days, created_at, last_accessed "
-            "FROM comparisons ORDER BY created_at DESC"
-        )
+    user = await auth.get_optional_user(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    columns = (
+        "SELECT id, name, show_name, total_rows, total_columns, "
+        "expiration_type, expiration_days, created_at, last_accessed "
+        "FROM comparisons"
     )
+    if auth.is_admin(user):
+        rows = query_dicts(f"{columns} ORDER BY created_at DESC")
+    else:
+        rows = query_dicts(f"{columns} WHERE user_id = ? ORDER BY created_at DESC", (user["id"],))
     comparisons = []
     for row in rows:
         comparison_id = row["id"]

--- a/auth.py
+++ b/auth.py
@@ -272,6 +272,34 @@ def set_admin_status(user_id: int, admin_status: bool):
         cursor.execute("UPDATE users SET is_admin = ? WHERE id = ?", (admin_status, user_id))
 
 
+# Invitation codes that shipped as defaults or copy-paste examples in earlier versions:
+# the migration fallback, the image's ENV default, and the value in both compose files.
+PLACEHOLDER_ADMIN_CODES = (
+    "admin-setup-123456",
+    "change-me-in-production",
+    "your-secure-admin-code",
+)
+
+
+def admin_uses_placeholder_code() -> bool:
+    """Report whether the admin account still uses a code that shipped as a default."""
+    try:
+        with get_db_cursor() as cursor:
+            cursor.execute(
+                "SELECT invitation_code_hash FROM users WHERE username = ?",
+                ("admin",),
+            )
+            row = cursor.fetchone()
+    except Exception:
+        return False
+
+    if not row or not row[0]:
+        return False
+
+    known = {hashlib.sha256(code.encode()).hexdigest() for code in PLACEHOLDER_ADMIN_CODES}
+    return row[0] in known
+
+
 # --- API Key Management ---
 
 

--- a/auth.py
+++ b/auth.py
@@ -3,6 +3,7 @@ Authentication module for Comps.
 Handles user authentication, invitation codes, and session management.
 """
 
+import base64
 import hashlib
 import os
 import secrets
@@ -52,9 +53,72 @@ def get_db_cursor() -> Generator[Any, None, None]:
             raise
 
 
+SCRYPT_N = 2**14
+SCRYPT_R = 8
+SCRYPT_P = 1
+SCRYPT_DKLEN = 32
+# 128 * N * r bytes are needed to derive; OpenSSL's default ceiling is lower than that.
+SCRYPT_MAXMEM = 128 * SCRYPT_N * SCRYPT_R * 2
+
+
+def _scrypt_hash(code: str, salt: bytes) -> str:
+    """Derive a versioned scrypt hash so the parameters travel with the stored value."""
+    derived = hashlib.scrypt(
+        code.encode(),
+        salt=salt,
+        n=SCRYPT_N,
+        r=SCRYPT_R,
+        p=SCRYPT_P,
+        dklen=SCRYPT_DKLEN,
+        maxmem=SCRYPT_MAXMEM,
+    )
+    return "scrypt${}${}${}${}${}".format(
+        SCRYPT_N,
+        SCRYPT_R,
+        SCRYPT_P,
+        base64.b64encode(salt).decode(),
+        base64.b64encode(derived).decode(),
+    )
+
+
 def hash_invitation_code(code: str) -> str:
-    """Hash an invitation code for secure storage"""
-    return hashlib.sha256(code.encode()).hexdigest()
+    """Hash an invitation code for storage."""
+    return _scrypt_hash(code, secrets.token_bytes(16))
+
+
+def verify_invitation_code_hash(code: str, stored: str) -> bool:
+    """Check a code against a stored hash, accepting the legacy unsalted digest."""
+    if not stored:
+        return False
+
+    if stored.startswith("scrypt$"):
+        try:
+            _, n, r, p, salt_b64, expected_b64 = stored.split("$")
+            candidate = hashlib.scrypt(
+                code.encode(),
+                salt=base64.b64decode(salt_b64),
+                n=int(n),
+                r=int(r),
+                p=int(p),
+                dklen=SCRYPT_DKLEN,
+                maxmem=128 * int(n) * int(r) * 2,
+            )
+            expected = base64.b64decode(expected_b64)
+        except (ValueError, TypeError):
+            return False
+        return secrets.compare_digest(candidate, expected)
+
+    legacy = hashlib.sha256(code.encode()).hexdigest()
+    return secrets.compare_digest(legacy, stored)
+
+
+def _upgrade_stored_hash(user_id: int, code: str) -> None:
+    """Re-store a legacy hash in the current format after a successful login."""
+    with get_db_cursor() as cursor:
+        cursor.execute(
+            "UPDATE users SET invitation_code_hash = ? WHERE id = ?",
+            (hash_invitation_code(code), user_id),
+        )
 
 
 def create_invitation_code(created_by_id: int) -> str:
@@ -109,9 +173,13 @@ def register_user(username: str, invitation_code: str) -> Optional[Dict[str, Any
         if user:
             user_id = user[0]
             with get_db_cursor() as cursor:
+                # Clear the cleartext as it is redeemed: from here it is the
+                # account's login credential, not a shareable signup token.
                 cursor.execute(
                     """
-                    UPDATE invitation_codes SET is_used = ?, used_by = ? WHERE code = ?
+                    UPDATE invitation_codes
+                    SET is_used = ?, used_by = ?, code = NULL
+                    WHERE code = ?
                     """,
                     (True, user_id, invitation_code),
                 )
@@ -130,25 +198,29 @@ def register_user(username: str, invitation_code: str) -> Optional[Dict[str, Any
 
 def authenticate_user(username: str, invitation_code: str) -> Optional[Dict[str, Any]]:
     """Authenticate a user with their username and invitation code"""
-    code_hash = hash_invitation_code(invitation_code)
+    # A salted hash cannot be matched in SQL, so fetch by username and verify here.
     with get_db_cursor() as cursor:
         cursor.execute(
             """
-            SELECT id, username, is_admin, never_expire_comparisons FROM users
-            WHERE username = ? AND invitation_code_hash = ?
+            SELECT id, username, is_admin, never_expire_comparisons, invitation_code_hash
+            FROM users WHERE username = ?
             """,
-            (username, code_hash),
+            (username,),
         )
         user = cursor.fetchone()
 
-    if user:
-        return {
-            "id": user[0],
-            "username": user[1],
-            "is_admin": bool(user[2]),
-            "never_expire_comparisons": bool(user[3]),
-        }
-    return None
+    if not user or not verify_invitation_code_hash(invitation_code, user[4]):
+        return None
+
+    if not user[4].startswith("scrypt$"):
+        _upgrade_stored_hash(user[0], invitation_code)
+
+    return {
+        "id": user[0],
+        "username": user[1],
+        "is_admin": bool(user[2]),
+        "never_expire_comparisons": bool(user[3]),
+    }
 
 
 def create_access_token(data: dict) -> str:
@@ -296,8 +368,9 @@ def admin_uses_placeholder_code() -> bool:
     if not row or not row[0]:
         return False
 
-    known = {hashlib.sha256(code.encode()).hexdigest() for code in PLACEHOLDER_ADMIN_CODES}
-    return row[0] in known
+    # Verify rather than compare digests: stored hashes are salted, so equality
+    # against a precomputed value would stop matching and silence this check.
+    return any(verify_invitation_code_hash(code, row[0]) for code in PLACEHOLDER_ADMIN_CODES)
 
 
 # --- API Key Management ---

--- a/database.py
+++ b/database.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from db import backend_name, execute, query, query_one
 from migrations.manager import MigrationManager
@@ -74,6 +74,29 @@ def create_comparison(
                 "INSERT INTO tags (comparison_id, tag) VALUES (?, ?)",
                 (comparison_id, tag),
             )
+
+
+def set_comparison_edit_token(comparison_id: str, token_hash: str, expires_at: int):
+    """Store the hash of the edit token that authorizes writes to a comparison.
+
+    expires_at is a Unix timestamp so the comparison is free of the timezone
+    ambiguity that affects the TIMESTAMP columns on this table.
+    """
+    execute(
+        "UPDATE comparisons SET edit_token_hash = ?, edit_token_expires_at = ? WHERE id = ?",
+        (token_hash, expires_at, comparison_id),
+    )
+
+
+def get_comparison_edit_token(comparison_id: str) -> Tuple[Optional[str], Optional[int]]:
+    """Return the stored edit token hash and its expiry, or (None, None) if it has none."""
+    row = query_one(
+        "SELECT edit_token_hash, edit_token_expires_at FROM comparisons WHERE id = ?",
+        (comparison_id,),
+    )
+    if not row or not row[0]:
+        return None, None
+    return row[0], row[1]
 
 
 def update_last_accessed(comparison_id: str):

--- a/database.py
+++ b/database.py
@@ -310,31 +310,25 @@ def get_expired_comparisons(retention_days: int):
             print(f"  Comparison {comp_id} is marked as never expire, skipping")
             continue
 
-        if exp_type == "from_creation" and created_at:
-            # Support both string and datetime types across backends
-            created_dt = (
-                created_at
-                if isinstance(created_at, datetime)
-                else datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S")
-            )
-            cutoff_date = created_dt + timedelta(days=days)
-            print(
-                f"  From creation: cutoff={cutoff_date}, current={current_time}, expired={current_time > cutoff_date}"  # noqa: E501
-            )
-            if current_time > cutoff_date:
-                expired_ids.append(comp_id)
-        elif exp_type == "from_last_access" and last_accessed:
-            last_dt = (
-                last_accessed
-                if isinstance(last_accessed, datetime)
-                else datetime.strptime(last_accessed, "%Y-%m-%d %H:%M:%S")
-            )
-            cutoff_date = last_dt + timedelta(days=days)
-            print(
-                f"  From last access: cutoff={cutoff_date}, current={current_time}, expired={current_time > cutoff_date}"  # noqa: E501
-            )
-            if current_time > cutoff_date:
-                expired_ids.append(comp_id)
+        # Anything other than from_creation falls back to last access, and last access
+        # falls back to creation, so no row can escape the sweep by carrying an
+        # unrecognised type or a null timestamp.
+        reference = created_at if exp_type == "from_creation" else (last_accessed or created_at)
+        if reference is None:
+            continue
+
+        # Support both string and datetime types across backends
+        reference_dt = (
+            reference
+            if isinstance(reference, datetime)
+            else datetime.strptime(reference, "%Y-%m-%d %H:%M:%S")
+        )
+        cutoff_date = reference_dt + timedelta(days=days)
+        print(
+            f"  cutoff={cutoff_date}, current={current_time}, expired={current_time > cutoff_date}"
+        )
+        if current_time > cutoff_date:
+            expired_ids.append(comp_id)
     return expired_ids
 
 

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -33,7 +33,7 @@ services:
       - DB_BACKEND=postgres
       - DATABASE_URL=postgresql://comps:compspass@db:5432/comps
       - UPLOADS_PATH=/data/uploads
-      - ADMIN_INVITATION_CODE=your-secure-admin-code
+      - ADMIN_INVITATION_CODE=${ADMIN_INVITATION_CODE:?set this to a strong value}
     volumes:
       - ./config:/config
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - PGID=1000
       - DB_PATH=/config/comparisons.db
       - UPLOADS_PATH=/data/uploads
-      - ADMIN_INVITATION_CODE=your-secure-admin-code
+      - ADMIN_INVITATION_CODE=${ADMIN_INVITATION_CODE:?set this to a strong value}
     volumes:
       - ./config:/config
       - ./data:/data

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, Form, HTTPException, Request, status
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import APIKeyCookie
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -31,7 +31,13 @@ from database import (
 )
 from database_metrics import get_metrics
 from db import backend_name, query_dicts
-from storage import ensure_storage_ready, get_presigned_image_url, is_s3_enabled
+from storage import (
+    ensure_storage_ready,
+    get_content_type_for,
+    get_local_image_path,
+    get_presigned_image_url,
+    is_s3_enabled,
+)
 
 
 # Random name generator for comparisons
@@ -133,24 +139,30 @@ app.include_router(api_router)
 
 # Mount static files and templates
 app.mount("/static", StaticFiles(directory="static"), name="static")
-if not is_s3_enabled():
-    app.mount(
-        "/uploads", StaticFiles(directory=os.getenv("UPLOADS_PATH", "uploads")), name="uploads"
-    )
 templates = Jinja2Templates(directory="templates")
 
 
 @app.get("/uploads/{path:path}", include_in_schema=False, name="uploads")
 async def serve_uploaded_image(path: str):
-    if not is_s3_enabled():
-        raise HTTPException(status_code=404, detail="Image not found")
-
     if "/" not in path:
         raise HTTPException(status_code=404, detail="Image not found")
 
     comparison_id, filename = path.split("/", 1)
     if not comparison_id or not filename:
         raise HTTPException(status_code=404, detail="Image not found")
+
+    if not is_s3_enabled():
+        # Serve with a content type from the server-side map so a stored file cannot
+        # dictate how the browser interprets it.
+        try:
+            file_path = get_local_image_path(comparison_id, filename)
+        except (FileNotFoundError, OSError) as e:
+            raise HTTPException(status_code=404, detail="Image not found") from e
+        return FileResponse(
+            file_path,
+            media_type=get_content_type_for(filename),
+            headers={"X-Content-Type-Options": "nosniff"},
+        )
 
     try:
         presigned_url = get_presigned_image_url(comparison_id, filename)

--- a/main.py
+++ b/main.py
@@ -242,6 +242,16 @@ async def start_cleanup_task():
     except Exception as e:
         logger.error("Error checking database state: %s", str(e))
 
+    if auth.admin_uses_placeholder_code():
+        logger.warning(
+            "The 'admin' account still uses an invitation code that shipped as a default."
+        )
+        logger.warning(
+            "Setting ADMIN_INVITATION_CODE now has no effect: the account was created "
+            "by a migration that has already run."
+        )
+        logger.warning("Rotate it with: python scripts/rotate_admin_code.py --username admin")
+
 
 @app.get("/health")
 async def health_check():

--- a/migrations/versions/006_add_user_authentication.py
+++ b/migrations/versions/006_add_user_authentication.py
@@ -86,14 +86,16 @@ def upgrade(cursor):
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_invitation_codes_code ON invitation_codes(code)')
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_comparisons_user_id ON comparisons(user_id)')
     
-    # Create first admin user with a predefined invitation code
+    # Create first admin user with an invitation code supplied by the operator
     import hashlib
-    # Get admin code from environment variable or use default (for initial setup only)
-    admin_code = os.getenv("ADMIN_INVITATION_CODE", "admin-setup-123456")
-    # Log a warning if using the default admin code
-    if admin_code == "admin-setup-123456":
-        logging.warning("WARNING: Using default admin invitation code. This is insecure!")
-        logging.warning("Set the ADMIN_INVITATION_CODE environment variable to a secure value.")
+    import secrets
+    admin_code = os.getenv("ADMIN_INVITATION_CODE", "").strip()
+    if not admin_code:
+        # Nothing configured: generate a code so the install is usable but not predictable.
+        admin_code = secrets.token_urlsafe(24)
+        logging.warning("ADMIN_INVITATION_CODE was not set.")
+        logging.warning("Generated admin invitation code for first-time setup: %s", admin_code)
+        logging.warning("Record this value now; it is not displayed again.")
     admin_code_hash = hashlib.sha256(admin_code.encode()).hexdigest()
     
     # Ensure admin user exists (idempotent)

--- a/migrations/versions/009_add_comparison_edit_token.py
+++ b/migrations/versions/009_add_comparison_edit_token.py
@@ -1,0 +1,48 @@
+"""Add an edit token hash to comparisons for authorizing anonymous writes
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-08-16 12:00:00
+
+"""
+
+# revision identifiers, used by the migration system
+revision = '009'
+down_revision = '008_add_api_keys_table'
+
+from db import backend_name
+
+def upgrade(cursor):
+    """Add the edit token columns to the comparisons table.
+
+    edit_token_expires_at holds a Unix timestamp rather than a TIMESTAMP so the
+    expiry check does not depend on how each backend interprets CURRENT_TIMESTAMP.
+    """
+    if backend_name() == "postgres":
+        cursor.execute(
+            """
+            ALTER TABLE comparisons
+            ADD COLUMN IF NOT EXISTS edit_token_hash TEXT
+            """
+        )
+        cursor.execute(
+            """
+            ALTER TABLE comparisons
+            ADD COLUMN IF NOT EXISTS edit_token_expires_at BIGINT
+            """
+        )
+    else:
+        # SQLite: check the schema first so a re-run does not raise.
+        cursor.execute("PRAGMA table_info(comparisons)")
+        cols = [row[1] for row in cursor.fetchall()]
+        if 'edit_token_hash' not in cols:
+            cursor.execute("ALTER TABLE comparisons ADD COLUMN edit_token_hash TEXT")
+        if 'edit_token_expires_at' not in cols:
+            cursor.execute("ALTER TABLE comparisons ADD COLUMN edit_token_expires_at INTEGER")
+
+def downgrade(_cursor):
+    """No-op downgrade.
+
+    SQLite cannot drop a column without recreating the table, which is
+    intentionally skipped here.
+    """

--- a/migrations/versions/010_protect_invitation_codes.py
+++ b/migrations/versions/010_protect_invitation_codes.py
@@ -1,0 +1,75 @@
+"""Store invitation codes without recoverable cleartext once redeemed
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-08-16 12:00:00
+
+"""
+
+# revision identifiers, used by the migration system
+revision = '010'
+down_revision = '009_add_comparison_edit_token'
+
+import base64
+import hashlib
+import secrets
+
+from db import backend_name
+
+def _scrypt_hash(code):
+    """Match the versioned format produced by auth._scrypt_hash."""
+    salt = secrets.token_bytes(16)
+    derived = hashlib.scrypt(
+        code.encode(), salt=salt, n=2**14, r=8, p=1, dklen=32, maxmem=128 * 2**14 * 8 * 2
+    )
+    return "scrypt$16384$8$1${}${}".format(
+        base64.b64encode(salt).decode(), base64.b64encode(derived).decode()
+    )
+
+def upgrade(cursor):
+    """Allow cleartext to be cleared, upgrade stored hashes, then clear redeemed codes."""
+    # The code column must accept NULL so a redeemed code can be discarded.
+    if backend_name() == "postgres":
+        cursor.execute("ALTER TABLE invitation_codes ALTER COLUMN code DROP NOT NULL")
+    else:
+        # SQLite cannot drop a NOT NULL constraint in place, so recreate the table.
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS invitation_codes_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT UNIQUE,
+                created_by INTEGER,
+                is_used BOOLEAN DEFAULT 0,
+                used_by INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (created_by) REFERENCES users (id),
+                FOREIGN KEY (used_by) REFERENCES users (id)
+            )
+        ''')
+        cursor.execute('''
+            INSERT INTO invitation_codes_new (id, code, created_by, is_used, used_by, created_at)
+            SELECT id, code, created_by, is_used, used_by, created_at FROM invitation_codes
+        ''')
+        cursor.execute('DROP TABLE invitation_codes')
+        cursor.execute('ALTER TABLE invitation_codes_new RENAME TO invitation_codes')
+        cursor.execute(
+            'CREATE INDEX IF NOT EXISTS idx_invitation_codes_code ON invitation_codes(code)'
+        )
+
+    # Upgrade credentials to salted hashes while the cleartext is still recoverable.
+    cursor.execute('''
+        SELECT u.id, ic.code
+        FROM users u
+        JOIN invitation_codes ic ON ic.used_by = u.id
+        WHERE ic.code IS NOT NULL
+    ''')
+    for user_id, code in cursor.fetchall():
+        cursor.execute(
+            'UPDATE users SET invitation_code_hash = ? WHERE id = ?',
+            (_scrypt_hash(code), user_id)
+        )
+
+    # Discard the cleartext of codes that have already been redeemed.
+    cursor.execute('UPDATE invitation_codes SET code = NULL WHERE is_used = ?', (True,))
+
+def downgrade(_cursor):
+    """No-op downgrade. Discarded cleartext cannot be recovered."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-# Development requirements for formatting and linting
-black
-isort
-flake8
-djlint
-pre-commit
-setuptools
-httpx
-pytest
-pytest-cov
+# Development requirements for formatting, linting and tests
+black==26.5.1
+isort==8.0.1
+flake8==7.3.0
+djlint==1.44.2
+pre-commit==4.6.2
+setuptools==84.0.0
+httpx==0.28.1
+pytest==9.1.1
+pytest-cov==7.1.0

--- a/scripts/rotate_admin_code.py
+++ b/scripts/rotate_admin_code.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Rotate the invitation code that an account uses to sign in.
+
+The invitation code doubles as the account's login credential, and there is no
+in-app way to change it. Use this after an install has been running with a code
+that shipped as a default, or whenever a credential needs replacing.
+
+Usage:
+  python scripts/rotate_admin_code.py
+  python scripts/rotate_admin_code.py --username admin
+  python scripts/rotate_admin_code.py --username admin --code "<value>"
+"""
+
+from __future__ import annotations
+
+import argparse
+import secrets
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path.
+ROOT = str(Path(__file__).resolve().parents[1])
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from auth import hash_invitation_code  # noqa: E402
+from db import execute, query_one  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Rotate an account's invitation code.")
+    parser.add_argument("--username", default="admin", help="Account to rotate.")
+    parser.add_argument("--code", default=None, help="New code. Generated if omitted.")
+    args = parser.parse_args()
+
+    row = query_one("SELECT id FROM users WHERE username = ?", (args.username,))
+    if not row:
+        print(f"No user named {args.username!r}.")
+        return 1
+
+    new_code = args.code or secrets.token_urlsafe(24)
+    execute(
+        "UPDATE users SET invitation_code_hash = ? WHERE id = ?",
+        (hash_invitation_code(new_code), row[0]),
+    )
+
+    print(f"Rotated the invitation code for {args.username!r}.")
+    print(f"New code: {new_code}")
+    print("Record this value now; it is not stored in recoverable form.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -1494,7 +1494,7 @@ document.getElementById("upload-button").addEventListener("click", async () => {
             );
         }
 
-        const { comparison_id } = await comparisonResponse.json();
+        const { comparison_id, edit_token } = await comparisonResponse.json();
 
         // 2. Upload each file individually
         const filesToUpload = [];
@@ -1525,6 +1525,7 @@ document.getElementById("upload-button").addEventListener("click", async () => {
                 `/api/v1/comparison/${comparison_id}/image`,
                 {
                     method: "POST",
+                    headers: edit_token ? { "X-Edit-Token": edit_token } : {},
                     body: imageFormData,
                 },
             );

--- a/storage.py
+++ b/storage.py
@@ -1,4 +1,3 @@
-import mimetypes
 import os
 import shutil
 import uuid
@@ -18,6 +17,17 @@ S3_REGION = os.getenv("S3_REGION")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
 S3_KEY_PREFIX = os.getenv("S3_KEY_PREFIX", "").strip().strip("/")
 S3_PRESIGNED_URL_TTL_SECONDS = int(os.getenv("S3_PRESIGNED_URL_TTL_SECONDS", "3600"))
+
+ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+EXTENSION_CONTENT_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
 
 _s3_client = None
 
@@ -53,9 +63,8 @@ async def save_upload_file(comparison_id: str, filename: str, file: UploadFile) 
     safe_comparison_id = _normalize_comparison_id(comparison_id)
     safe_filename = _normalize_filename(filename)
     await file.seek(0)
-    content_type = (
-        file.content_type or mimetypes.guess_type(safe_filename)[0] or "application/octet-stream"
-    )
+    # Derive the type from the server-side map rather than trusting the client.
+    content_type = get_content_type_for(safe_filename)
 
     if is_s3_enabled():
         key = _get_object_key(safe_comparison_id, safe_filename)
@@ -201,6 +210,21 @@ def _delete_s3_keys(client, keys: list[str]):
                 for err in errors
             )
             raise OSError(f"S3 reported delete errors: {details}")
+
+
+def get_content_type_for(filename: str) -> str:
+    """Return a content type from the server-side allowlist, never from client input."""
+    return EXTENSION_CONTENT_TYPES.get(Path(filename).suffix.lower(), "application/octet-stream")
+
+
+def get_local_image_path(comparison_id: str, filename: str) -> Path:
+    """Resolve a stored image on the local filesystem, rejecting traversal attempts."""
+    safe_comparison_id = _normalize_comparison_id(comparison_id)
+    safe_filename = _normalize_filename(filename)
+    path = Path(UPLOADS_PATH) / safe_comparison_id / safe_filename
+    if not path.is_file():
+        raise FileNotFoundError(f"Image not found: {safe_comparison_id}/{safe_filename}")
+    return path
 
 
 def _normalize_comparison_id(comparison_id: str) -> str:

--- a/templates/admin.jinja
+++ b/templates/admin.jinja
@@ -29,7 +29,7 @@
                     <tbody>
                     {% for code in invitation_codes %}
                     <tr>
-                        <td><code>{{ code.code }}</code></td>
+                        <td><code>{{ code.code or 'Redeemed' }}</code></td>
                         <td>
                             {% if code.is_used %}
                             <span class="badge bg-success">Used</span>

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,6 +1,17 @@
+from io import BytesIO
+
+from PIL import Image
+
 import auth
 import database
-from db import query_one
+from db import execute, query_one
+
+
+def png_bytes():
+    """A real PNG, so these cases keep working once uploads are content-checked."""
+    buffer = BytesIO()
+    Image.new("RGB", (2, 2), (255, 0, 0)).save(buffer, format="PNG")
+    return buffer.getvalue()
 
 
 def test_api_login_accepts_valid_credentials(client, make_user):
@@ -75,6 +86,64 @@ def test_comparison_listing_is_scoped_to_the_caller(client, api_credentials, mak
 
     assert [row["name"] for row in owned.json()] == ["Mine"]
     assert {row["name"] for row in everything.json()} == {"Mine", "Theirs"}
+
+
+def test_ownerless_comparison_write_requires_the_edit_token(client):
+    created = client.post("/api/v1/comparison", data={"name": "Anon"}).json()
+    comparison_id = created["comparison_id"]
+    form = {"row": "0", "column": "0", "original_filename": "shot.png"}
+    upload = {"file": ("shot.png", png_bytes(), "image/png")}
+
+    without = client.post(f"/api/v1/comparison/{comparison_id}/image", data=form, files=upload)
+    wrong = client.post(
+        f"/api/v1/comparison/{comparison_id}/image",
+        headers={"X-Edit-Token": "not-the-token"},
+        data=form,
+        files=upload,
+    )
+    correct = client.post(
+        f"/api/v1/comparison/{comparison_id}/image",
+        headers={"X-Edit-Token": created["edit_token"]},
+        data=form,
+        files=upload,
+    )
+
+    assert without.status_code == 403
+    assert wrong.status_code == 403
+    assert correct.status_code == 200
+
+
+def test_edit_token_stops_working_once_expired(client):
+    created = client.post("/api/v1/comparison", data={"name": "Anon"}).json()
+    execute(
+        "UPDATE comparisons SET edit_token_expires_at = ? WHERE id = ?",
+        (1, created["comparison_id"]),
+    )
+
+    response = client.post(
+        f"/api/v1/comparison/{created['comparison_id']}/image",
+        headers={"X-Edit-Token": created["edit_token"]},
+        data={"row": "0", "column": "0", "original_filename": "shot.png"},
+        files={"file": ("shot.png", png_bytes(), "image/png")},
+    )
+
+    assert response.status_code == 403
+
+
+def test_owned_comparison_needs_no_edit_token(client, api_credentials):
+    _, headers = api_credentials
+    created = client.post("/api/v1/comparison", headers=headers, data={"name": "Owned"}).json()
+
+    assert "edit_token" not in created
+
+    response = client.post(
+        f"/api/v1/comparison/{created['comparison_id']}/image",
+        headers=headers,
+        data={"row": "0", "column": "0", "original_filename": "shot.png"},
+        files={"file": ("shot.png", png_bytes(), "image/png")},
+    )
+
+    assert response.status_code == 200
 
 
 def test_json_comparison_rejects_invalid_expiration(client):

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -50,12 +50,31 @@ def test_json_comparison_create_list_and_detail(client, api_credentials):
     assert query_one("SELECT user_id FROM comparisons WHERE id = ?", (comparison_id,))[0] == user_id
     assert created.json()["expiration_days"] == 30
 
-    listed = client.get("/api/v1/comparisons")
+    listed = client.get("/api/v1/comparisons", headers=headers)
     detailed = client.get(f"/api/v1/comparisons/{comparison_id}")
     assert listed.status_code == 200
     assert listed.json()[0]["tags"] == ["api", "test"]
     assert detailed.status_code == 200
     assert detailed.json()["images"] == []
+
+
+def test_comparison_listing_requires_authentication(client):
+    assert client.get("/api/v1/comparisons").status_code == 401
+
+
+def test_comparison_listing_is_scoped_to_the_caller(client, api_credentials, make_user):
+    _, owner_headers = api_credentials
+    admin_id = make_user(username="boss", invitation_code="boss-code", is_admin=True)
+    admin_headers = {"Authorization": auth.create_api_key(admin_id, "admin")}
+
+    client.post("/api/v1/comparisons", headers=owner_headers, json={"name": "Mine"})
+    client.post("/api/v1/comparisons", headers=admin_headers, json={"name": "Theirs"})
+
+    owned = client.get("/api/v1/comparisons", headers=owner_headers)
+    everything = client.get("/api/v1/comparisons", headers=admin_headers)
+
+    assert [row["name"] for row in owned.json()] == ["Mine"]
+    assert {row["name"] for row in everything.json()} == {"Mine", "Theirs"}
 
 
 def test_json_comparison_rejects_invalid_expiration(client):

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -146,6 +146,46 @@ def test_owned_comparison_needs_no_edit_token(client, api_credentials):
     assert response.status_code == 200
 
 
+def test_upload_rejects_non_image_content(client):
+    created = client.post("/api/v1/comparison", data={"name": "Anon"}).json()
+    headers = {"X-Edit-Token": created["edit_token"]}
+    url = f"/api/v1/comparison/{created['comparison_id']}/image"
+    payload = b"<script>alert(document.domain)</script>"
+
+    disallowed_extension = client.post(
+        url,
+        headers=headers,
+        data={"row": "0", "column": "0", "original_filename": "payload.html"},
+        files={"file": ("payload.html", payload, "text/html")},
+    )
+    disguised_as_image = client.post(
+        url,
+        headers=headers,
+        data={"row": "0", "column": "0", "original_filename": "payload.png"},
+        files={"file": ("payload.png", payload, "image/png")},
+    )
+
+    assert disallowed_extension.status_code == 400
+    assert disguised_as_image.status_code == 400
+
+
+def test_uploaded_image_is_served_with_a_pinned_content_type(client):
+    created = client.post("/api/v1/comparison", data={"name": "Anon"}).json()
+    comparison_id = created["comparison_id"]
+    uploaded = client.post(
+        f"/api/v1/comparison/{comparison_id}/image",
+        headers={"X-Edit-Token": created["edit_token"]},
+        data={"row": "0", "column": "0", "original_filename": "shot.png"},
+        files={"file": ("shot.png", png_bytes(), "image/png")},
+    )
+
+    served = client.get(f"/uploads/{comparison_id}/{uploaded.json()['filename']}")
+
+    assert served.status_code == 200
+    assert served.headers["content-type"] == "image/png"
+    assert served.headers["x-content-type-options"] == "nosniff"
+
+
 def test_json_comparison_rejects_invalid_expiration(client):
     response = client.post(
         "/api/v1/comparisons",
@@ -200,7 +240,7 @@ def test_owned_image_upload_update_and_delete(client, api_credentials, make_user
         user_id=owner_id,
     )
     upload = {
-        "file": ("image.png", b"image bytes", "image/png"),
+        "file": ("image.png", png_bytes(), "image/png"),
     }
     form = {"row": "0", "column": "0", "original_filename": "image.png"}
 

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -47,7 +47,12 @@ class ComparisonWriteAccessTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.status_code, 403)
 
-    def test_anonymous_comparison_remains_editable(self):
+    def test_ownerless_comparison_is_not_gated_by_ownership(self):
+        """An ownerless comparison has no owner to check, so this helper defers.
+
+        Writes to it are gated by the edit token instead; see the route-level
+        cases in test_api_routes.py.
+        """
         require_comparison_write_access({"user_id": None}, None)
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -32,6 +32,49 @@ def test_invitation_registration_and_authentication(isolated_db):
     assert auth.register_user("another-user", code) is None
 
 
+def test_redeemed_code_is_no_longer_recoverable(isolated_db):
+    admin_id = query_one("SELECT id FROM users WHERE username = 'admin'")[0]
+    code = auth.create_invitation_code(admin_id)
+
+    # Unredeemed codes stay readable so an admin can still share them.
+    assert query_one("SELECT code FROM invitation_codes WHERE code = ?", (code,))
+
+    user = auth.register_user("redeemer", code)
+    stored_code = query_one("SELECT code FROM invitation_codes WHERE used_by = ?", (user["id"],))[0]
+    stored_hash = query_one("SELECT invitation_code_hash FROM users WHERE id = ?", (user["id"],))[0]
+
+    assert stored_code is None
+    assert stored_hash.startswith("scrypt$")
+    # The credential still works even though the cleartext is gone.
+    assert auth.authenticate_user("redeemer", code)["id"] == user["id"]
+
+
+def test_legacy_hashes_authenticate_and_are_upgraded(isolated_db, make_user):
+    user_id = make_user(invitation_code="legacy-code")
+
+    before = query_one("SELECT invitation_code_hash FROM users WHERE id = ?", (user_id,))[0]
+    authenticated = auth.authenticate_user("student", "legacy-code")
+    after = query_one("SELECT invitation_code_hash FROM users WHERE id = ?", (user_id,))[0]
+
+    assert not before.startswith("scrypt$")
+    assert authenticated["id"] == user_id
+    assert after.startswith("scrypt$")
+    # The upgraded hash still verifies the same credential.
+    assert auth.authenticate_user("student", "legacy-code")["id"] == user_id
+    assert auth.authenticate_user("student", "wrong-code") is None
+
+
+def test_placeholder_admin_code_is_detected(isolated_db):
+    assert auth.admin_uses_placeholder_code() is False
+
+    execute(
+        "UPDATE users SET invitation_code_hash = ? WHERE username = ?",
+        (auth.hash_invitation_code("change-me-in-production"), "admin"),
+    )
+
+    assert auth.admin_uses_placeholder_code() is True
+
+
 def test_tokens_resolve_users_and_reject_invalid_tokens(isolated_db, make_user):
     user_id = make_user()
     token = auth.create_access_token({"sub": str(user_id)})

--- a/tests/test_db_database.py
+++ b/tests/test_db_database.py
@@ -19,7 +19,7 @@ def test_migrations_create_complete_schema(isolated_db):
         "tags",
         "users",
     } <= tables
-    assert MigrationManager().get_current_version() == "009"
+    assert MigrationManager().get_current_version() == "010"
 
 
 def test_db_helpers_execute_and_query(isolated_db):

--- a/tests/test_db_database.py
+++ b/tests/test_db_database.py
@@ -19,7 +19,7 @@ def test_migrations_create_complete_schema(isolated_db):
         "tags",
         "users",
     } <= tables
-    assert MigrationManager().get_current_version() == "008"
+    assert MigrationManager().get_current_version() == "009"
 
 
 def test_db_helpers_execute_and_query(isolated_db):


### PR DESCRIPTION
### Fixes
- auth: require an explicit admin invitation code
- api: scope comparison listing to the authenticated caller
- api: authorize writes to a comparison
- uploads: restrict types and pin the served content type
- retention: close gaps that let a comparison skip the sweep
- auth: hash stored credentials and drop redeemed cleartext
- ci: pin third-party actions and lock lint dependencies